### PR TITLE
Update and rename dockerfile to DockerFile

### DIFF
--- a/DockerFile
+++ b/DockerFile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:22.04
 
 RUN apt-get update && apt-get install -y \
     endlessh \


### PR DESCRIPTION
I changed the Dockerfile filename from 'dockerfile' to 'DockerFile' for Podman compatibility and updated the Ubuntu version to a supported one.